### PR TITLE
Fix 2 set-cookie issue

### DIFF
--- a/login.go
+++ b/login.go
@@ -61,9 +61,13 @@ func (c *Client) login(ctx context.Context) error {
 		if cookie.Name == "3x-ui" {
 			c.sessionCookie = cookie
 			c.sessionExpires = cookie.Expires.Add(-6 * time.Hour)
-			return nil
 		}
 	}
+
+	if c.sessionCookie != nil {
+		return nil
+	}
+
 	return errors.New("session cookie not found")
 }
 


### PR DESCRIPTION
Backend sent 2 set-cookie header 3x-ui with different values. If we'll use first value as auth cookies - we'll get 404 error. If we'll use second value - it's ok. 

